### PR TITLE
Add missing MCC code 5262 (Garden supply stores)

### DIFF
--- a/mcc_data.go
+++ b/mcc_data.go
@@ -72,6 +72,7 @@ var mccData = map[string]Category{
 	"5231": {"5231", "Glass, paint and wallpaper shops"},
 	"5251": {"5251", "Hardware shops"},
 	"5261": {"5261", "Lawn and garden supply outlets, including nurseries"},
+	"5262": {"5262", "Garden supply stores"},
 	"5271": {"5271", "Mobile home dealers"},
 	"5300": {"5300", "Wholesale clubs"},
 	"5309": {"5309", "Duty-free shops"},


### PR DESCRIPTION
Fixes issue where MCC code 5262 was missing from the library, causing 'Not found mcc' errors for clients.

**Changes:**
- Added MCC 5262: Garden supply stores

**Verification:**
- Verified that MCC codes 5262, 5732, and 5462 are now all available
- All existing tests pass
- Tested all three codes successfully

**Related:**
- Addresses client errors for missing MCC codes: 5262, 5732, and 5462
- Note: 5732 and 5462 were already present in the library