### PR TITLE
Add support for MCC 3301 (Wizz Air)

### DIFF
--- a/mcc_data.go
+++ b/mcc_data.go
@@ -17,6 +17,7 @@ var mccData = map[string]Category{
 	"2741": {"2741", "Miscellaneous publishing and printing services"},
 	"2791": {"2791", "Typesetting, platemaking and related services"},
 	"2842": {"2842", "Speciality cleaning, polishing and sanitation preparations"},
+	"3301": {"3301", "Wizz Air"},
 	"4011": {"4011", "Railroads"},
 	"4111": {"4111", "Local and suburban commuter passenger transportation, including ferries"},
 	"4112": {"4112", "Passenger railways"},

--- a/mcc_test.go
+++ b/mcc_test.go
@@ -17,6 +17,7 @@ func TestGetCategory(t *testing.T) {
 		{"Valid code - 0743", "0743", "Wine producers", false},
 		{"Valid code - 0744", "0744", "Champagne producers", false},
 		{"Valid code - 0763", "0763", "Agricultural co-operatives", false},
+		{"Valid code - 3301", "3301", "Wizz Air", false},
 		{"Valid code - 5411", "5411", "Groceries and supermarkets", false},
 		{"Valid code - 5262", "5262", "Garden supply stores", false},
 		{"Non-existent code", "9999", "", true},
@@ -59,6 +60,7 @@ func TestGetCategoryWithCode(t *testing.T) {
 		err      bool
 	}{
 		{"Valid code", "5411", Category{Code: "5411", Description: "Groceries and supermarkets"}, false},
+		{"Valid airline code", "3301", Category{Code: "3301", Description: "Wizz Air"}, false},
 		{"Non-existent code", "9999", Category{}, true},
 		{"Empty code", "", Category{}, true},
 		{"Invalid format", "abc", Category{}, true},
@@ -92,7 +94,7 @@ func TestGetAllCategories(t *testing.T) {
 	}
 
 	// Test a few known categories
-	knownCodes := []string{"0742", "0743", "0744", "0763", "5411", "5262"}
+	knownCodes := []string{"0742", "0743", "0744", "0763", "3301", "5411", "5262"}
 	for _, code := range knownCodes {
 		if _, exists := categories[code]; !exists {
 			t.Errorf("GetAllCategories() missing known code %q", code)


### PR DESCRIPTION
## Summary
- add MCC 3301 (Wizz Air) to the static dataset
- cover the new code in GetCategory, GetCategoryWithCode, and GetAllCategories tests

## Testing
- GOCACHE=/tmp/go-build-mcc go test ./...