### PR TITLE
Add MCC 6513 category

### DIFF
--- a/mcc_data.go
+++ b/mcc_data.go
@@ -177,6 +177,7 @@ var mccData = map[string]Category{
 	"6051": {"6051", "Non-financial institutions -- foreign currency, money orders (not wire transfer), scrip and travellers' checks"},
 	"6211": {"6211", "Securities -- brokers and dealers"},
 	"6300": {"6300", "Insurance sales, underwriting and premiums"},
+	"6513": {"6513", "Real estate agents and managers -- rentals"},
 	"6540": {"6540", "Non-financial institutions -- stored value card purchase/load"},
 	"7011": {"7011", "Lodging -- hotels, motels and resorts"},
 	"7012": {"7012", "Timeshares"},

--- a/mcc_test.go
+++ b/mcc_test.go
@@ -18,6 +18,7 @@ func TestGetCategory(t *testing.T) {
 		{"Valid code - 0744", "0744", "Champagne producers", false},
 		{"Valid code - 0763", "0763", "Agricultural co-operatives", false},
 		{"Valid code - 3301", "3301", "Wizz Air", false},
+		{"Valid code - 6513", "6513", "Real estate agents and managers -- rentals", false},
 		{"Valid code - 5411", "5411", "Groceries and supermarkets", false},
 		{"Valid code - 5262", "5262", "Garden supply stores", false},
 		{"Non-existent code", "9999", "", true},
@@ -61,6 +62,7 @@ func TestGetCategoryWithCode(t *testing.T) {
 	}{
 		{"Valid code", "5411", Category{Code: "5411", Description: "Groceries and supermarkets"}, false},
 		{"Valid airline code", "3301", Category{Code: "3301", Description: "Wizz Air"}, false},
+		{"Valid rentals code", "6513", Category{Code: "6513", Description: "Real estate agents and managers -- rentals"}, false},
 		{"Non-existent code", "9999", Category{}, true},
 		{"Empty code", "", Category{}, true},
 		{"Invalid format", "abc", Category{}, true},
@@ -94,7 +96,7 @@ func TestGetAllCategories(t *testing.T) {
 	}
 
 	// Test a few known categories
-	knownCodes := []string{"0742", "0743", "0744", "0763", "3301", "5411", "5262"}
+	knownCodes := []string{"0742", "0743", "0744", "0763", "3301", "6513", "5411", "5262"}
 	for _, code := range knownCodes {
 		if _, exists := categories[code]; !exists {
 			t.Errorf("GetAllCategories() missing known code %q", code)


### PR DESCRIPTION
Adds MCC **6513** — _Real estate agents and managers -- rentals_ (ISO 18245) to the category database.

The morph service was logging `⚠️ MCC code not found: 6513` for rent-related transactions because this code was missing. Follows the same pattern as prior additions (e.g. #6, #7).

- Added `6513` entry to `mcc_data.go`
- Added test cases to `TestGetCategory`, `TestGetCategoryWithCode`, and the `knownCodes` list in `mcc_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)